### PR TITLE
update gemfile.lock to version 1.2.2 to address moderate security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (>=1.2.2)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)


### PR DESCRIPTION
update gemfile.lock to version 1.2.2 to address moderate security vulnerability